### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis-ci.yml
+++ b/.travis-ci.yml
@@ -1,0 +1,20 @@
+language: python
+matrix:
+  include:
+    - python: 3.4
+      env: TOXENV=py34
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
+# command to install dependencies
+install:
+  - pip install tox-travis
+# command to run tests
+script:
+  - python3 -m venv .venv
+  - source .venv/bin/activate
+  - python setup.py develop
+  - tox

--- a/tests/check-pip-version.sh
+++ b/tests/check-pip-version.sh
@@ -7,4 +7,5 @@ if [[ "$PIP_VERSION_OUTPUT" == *"$EXPECTED_PIP_VERSION"* ]]; then
     exit 0
 fi
 
+echo "Expected version ${EXPECTED_PIP_VERSION}, found ${PIP_VERSION_OUTPUT}"
 exit 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,23 @@
 [tox]
-env = flake8
+envlist = pip18_1, pip19_0_1, flake8
+usedevelop = True
+minversion = 2.0
 skipsdist = True
 
 [testenv]
-usedevelop = True
+basepython = python3
+whitelist_externals =
+  /bin/bash
+
+[testenv:pip18_1]
+pip_version = 18.1
+commands =
+  bash ./tests/check-pip-version.sh 18.1
+
+[testenv:pip19_0_1]
+pip_version = 19.0.1
+commands =
+  bash ./tests/check-pip-version.sh 19.0.1
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
1. Add tox configs to test pip 18.1 and 19.0.1
3. Add Travis CI configuration (running in all currently supported versions of Python 3 for completeness)