### PR TITLE
Add test for specifying pip version via environment variable

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pip18_1, pip19_0_1, flake8
+envlist = pip18_1, pip19_0_1, flake8, pip18_1_env
 usedevelop = True
 minversion = 2.0
 skipsdist = True
@@ -22,3 +22,9 @@ commands =
 [testenv:flake8]
 deps = flake8
 commands = flake8 ./tox_pip_version
+
+[testenv:pip18_1_env]
+setenv =
+  TOX_PIP_VERSION=18.1
+commands =
+  bash ./tests/check-pip-version.sh 18.1


### PR DESCRIPTION
Just adding an extra tox environment for configuring via environment variable instead of configuring in tox.ini.