### PR TITLE
Housekeeping

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.2
+current_version = 0.0.1
 files = setup.py
 commit = True
 tag = True

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.1
+current_version = 0.0.2
 files = setup.py
 commit = True
 tag = True

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 matrix:
   include:
+    - python: 2.7
+      env: TOXENV=py27
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5
@@ -17,7 +19,6 @@ install:
   - pip install tox-travis
 # command to run tests
 script:
-  - python setup.py develop
-  - make test
+  - make test dist
 notifications:
   email: false

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type='text/markdown',
     url='https://github.com/pglass/tox-pip-version',
     license='MIT',
-    version='0.0.1',
+    version='0.0.2',
     packages=setuptools.find_packages(),
     include_package_data=True,
     install_requires=['tox>=2.0'],

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setuptools.setup(
     author_email='pnglass@gmail.com',
     description='Select PIP version to use with tox',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     url='https://github.com/pglass/tox-pip-version',
     license='MIT',
     version='0.0.1',
@@ -29,6 +30,10 @@ setuptools.setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )

--- a/tests/test-env-inheritance/tox.ini
+++ b/tests/test-env-inheritance/tox.ini
@@ -1,6 +1,6 @@
 # Check that we can specify one pip version used for multiple envs
 [tox]
-envlist = py36, env1, env2
+envlist = env1, env2
 minversion = 2.0
 skipsdist = True
 


### PR DESCRIPTION
- Test with python 2.7
- Fix markdown rendering on PyPI
- Run `twine check` as part of the dist step
- Bump to 0.0.2

TODO:

- [x] upload to test pypi for testing (done: https://test.pypi.org/project/tox-pip-version/)