### PR TITLE
 Fix for compatibility with tox 3.8

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.2
+current_version = 0.0.3
 files = setup.py
 commit = True
 tag = True

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,17 @@ $(VENV):
 lint: $(VENV)
 	$(VENV_ACTIVATE); tox -e flake8
 
-test: clean-tests $(VENV) lint
+test: clean-tests $(VENV) lint test-tox-3.7 test-tox-3.8
+
+# TODO: Need to refactor to test more pip versions
+test-tox-3.8: clean-tests
+	$(VENV_ACTIVATE); pip install 'tox>=3.8,<3.9'
+	$(VENV_ACTIVATE); cd $(PWD)/tests/test-two-envs && $(TOX)
+	$(VENV_ACTIVATE); cd $(PWD)/tests/test-env-inheritance && $(TOX)
+	$(VENV_ACTIVATE); cd $(PWD)/tests/test-environment-variable && ./run-tox.sh $(TOX)
+
+test-tox-3.7: clean-tests
+	$(VENV_ACTIVATE); pip install 'tox>=3.7,<3.8'
 	$(VENV_ACTIVATE); cd $(PWD)/tests/test-two-envs && $(TOX)
 	$(VENV_ACTIVATE); cd $(PWD)/tests/test-env-inheritance && $(TOX)
 	$(VENV_ACTIVATE); cd $(PWD)/tests/test-environment-variable && ./run-tox.sh $(TOX)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ repeatable builds, but at the cost of using an outdated (possibly vulnerable)
 package. This should be used as a temporary fix for breakages in upstream pip,
 or in conjunction with a regular process to update the version pin.
 
+*Note*: This relies on an [unstable tox plugin interface](
+https://tox.readthedocs.io/en/latest/plugins.html#tox.hookspecs.tox_testenv_create).
+You may experience breakage with new tox versions. If you do, please feel
+free to [report the issue](https://github.com/pglass/tox-pip-version/issues/new)
+on Github.
 
 ### Usage
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type='text/markdown',
     url='https://github.com/pglass/tox-pip-version',
     license='MIT',
-    version='0.0.2',
+    version='0.0.3',
     packages=setuptools.find_packages(),
     include_package_data=True,
     install_requires=['tox>=2.0'],

--- a/tox_pip_version/hooks.py
+++ b/tox_pip_version/hooks.py
@@ -7,7 +7,7 @@ import tox.venv
 # This will store the pip version specified for each testenv
 PER_ENV_PIP_VERSIONS = {}
 
-TOX_PIP_VERSION_VAR = 'TOX_PIP_VERSION'
+TOX_PIP_VERSION_VAR = "TOX_PIP_VERSION"
 
 
 @tox.hookimpl
@@ -29,19 +29,22 @@ def tox_testenv_create(venv, action):
         TOX_PIP_VERSION_VAR, os.getenv(TOX_PIP_VERSION_VAR)
     )
 
-    # Use `pip_version` in tox.ini over the environment variable
+    # action.venvname is 'py36', for example.
     #
-    # action.venvname is 'py36', for example
-    # I see action.id == action.venvname - not sure which to use
-    pip_version = PER_ENV_PIP_VERSIONS.get(
-        action.venvname, tox_pip_version_from_env
-    )
+    # tox 3.8 changed action.venvname -> action.name, and removed action.id
+    try:
+        venvname = action.venvname
+    except AttributeError:
+        venvname = action.name
+
+    # Use `pip_version` in tox.ini over the environment variable
+    pip_version = PER_ENV_PIP_VERSIONS.get(venvname, tox_pip_version_from_env)
     if pip_version:
         # Is there a way to output this better? Genuine tox commands show up
         # colorized (as bold white text)...
-        print('%s: pip_version = %s' % (action.venvname, pip_version))
-        package = 'pip==%s' % pip_version
+        print("%s: pip_version = %s" % (venvname, pip_version))
+        package = "pip==%s" % pip_version
 
         # "private" _install method - unstable interface?
-        venv._install([package], extraopts=['-U'], action=action)
+        venv._install([package], extraopts=["-U"], action=action)
     return True


### PR DESCRIPTION
- Use either `Action.venvname` (tox 3.7) or `Action.name` (tox 3.8), whichever is present
- Test with both of tox 3.7 and tox 3.8
- Reformat code with [black](https://github.com/ambv/black)
- Bump to version 0.0.3 for a release

Fixes #7 