### PR TITLE
Include LICENSE and tests in sdist

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.3
+current_version = 0.0.4
 files = setup.py
 commit = True
 tag = True

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include tox.ini
+include LICENSE
+include MAKEFILE
+
+recursive-include tests *.sh *.ini

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type='text/markdown',
     url='https://github.com/pglass/tox-pip-version',
     license='MIT',
-    version='0.0.3',
+    version='0.0.4',
     packages=setuptools.find_packages(),
     include_package_data=True,
     install_requires=['tox>=2.0'],


### PR DESCRIPTION
Fixes #9 

Testing we've got LICENSE + tests in the sdist,

```bash
$ make clean-dist dist
...
$ tar -tf dist/tox-pip-version-0.0.4.tar.gz
tox-pip-version-0.0.4/
tox-pip-version-0.0.4/PKG-INFO
tox-pip-version-0.0.4/tox_pip_version.egg-info/
tox-pip-version-0.0.4/tox_pip_version.egg-info/PKG-INFO
tox-pip-version-0.0.4/tox_pip_version.egg-info/SOURCES.txt
tox-pip-version-0.0.4/tox_pip_version.egg-info/entry_points.txt
tox-pip-version-0.0.4/tox_pip_version.egg-info/requires.txt
tox-pip-version-0.0.4/tox_pip_version.egg-info/top_level.txt
tox-pip-version-0.0.4/tox_pip_version.egg-info/dependency_links.txt
tox-pip-version-0.0.4/tox_pip_version/
tox-pip-version-0.0.4/tox_pip_version/hooks.py
tox-pip-version-0.0.4/tox_pip_version/__init__.py
tox-pip-version-0.0.4/LICENSE
tox-pip-version-0.0.4/MAKEFILE
tox-pip-version-0.0.4/tests/
tox-pip-version-0.0.4/tests/check-pip-version.sh
tox-pip-version-0.0.4/tests/test-environment-variable/
tox-pip-version-0.0.4/tests/test-environment-variable/run-tox.sh
tox-pip-version-0.0.4/tests/test-environment-variable/tox.ini
tox-pip-version-0.0.4/tests/test-two-envs/
tox-pip-version-0.0.4/tests/test-two-envs/tox.ini
tox-pip-version-0.0.4/tests/test-env-inheritance/
tox-pip-version-0.0.4/tests/test-env-inheritance/tox.ini
tox-pip-version-0.0.4/MANIFEST.in
tox-pip-version-0.0.4/README.md
tox-pip-version-0.0.4/setup.py
tox-pip-version-0.0.4/tox.ini
tox-pip-version-0.0.4/setup.cfg
```

And making sure the tests are not installed,

```bash
$ tree .venv-test/lib/python3.6/site-packages/tox_pip_version*
.venv-test/lib/python3.6/site-packages/tox_pip_version
├── __init__.py
├── __pycache__
│   ├── __init__.cpython-36.pyc
│   └── hooks.cpython-36.pyc
└── hooks.py
.venv-test/lib/python3.6/site-packages/tox_pip_version-0.0.4.dist-info
├── INSTALLER
├── LICENSE
├── METADATA
├── RECORD
├── WHEEL
├── entry_points.txt
└── top_level.txt
```
