### PR TITLE
Be compatible with tox-venv

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,4 @@ include tox.ini
 include LICENSE
 include MAKEFILE
 
-recursive-include tests *.sh *.ini
+recursive-include tests *.py *.sh *.ini

--- a/Makefile
+++ b/Makefile
@@ -10,26 +10,14 @@ TOX = tox
 
 $(VENV):
 	virtualenv $(VENV)
-	$(VENV_ACTIVATE); pip install tox bumpversion twine 'readme_renderer[md]'
+	$(VENV_ACTIVATE); pip install -r dev-requirements.txt
 	$(VENV_ACTIVATE); pip install -e .
 
 lint: $(VENV)
 	$(VENV_ACTIVATE); tox -e flake8
 
-test: clean-tests $(VENV) lint test-tox-3.7 test-tox-3.8
-
-# TODO: Need to refactor to test more pip versions
-test-tox-3.8: clean-tests
-	$(VENV_ACTIVATE); pip install 'tox>=3.8,<3.9'
-	$(VENV_ACTIVATE); cd $(PWD)/tests/test-two-envs && $(TOX)
-	$(VENV_ACTIVATE); cd $(PWD)/tests/test-env-inheritance && $(TOX)
-	$(VENV_ACTIVATE); cd $(PWD)/tests/test-environment-variable && ./run-tox.sh $(TOX)
-
-test-tox-3.7: clean-tests
-	$(VENV_ACTIVATE); pip install 'tox>=3.7,<3.8'
-	$(VENV_ACTIVATE); cd $(PWD)/tests/test-two-envs && $(TOX)
-	$(VENV_ACTIVATE); cd $(PWD)/tests/test-env-inheritance && $(TOX)
-	$(VENV_ACTIVATE); cd $(PWD)/tests/test-environment-variable && ./run-tox.sh $(TOX)
+test: clean $(VENV) lint
+	$(VENV_ACTIVATE); pytest -v -n 8 tests/test.py
 
 dist: clean-dist $(VENV)
 	python setup.py sdist
@@ -53,11 +41,7 @@ release: clean test dist
 
 clean-dist:
 	rm -rf dist
+	rm -rf tox_pip_version.egg-info
 
-clean-tests:
-	find tests -name .tox -type d -exec rm -r "{}" +
-
-clean: clean-dist clean-tests
+clean: clean-dist
 	rm -rf $(VENV)
-
-

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ $(VENV):
 lint: $(VENV)
 	$(VENV_ACTIVATE); tox -e flake8
 
-test: clean $(VENV) lint
-	$(VENV_ACTIVATE); pytest -v -n 8 tests/test.py
+test: $(VENV) lint
+	$(VENV_ACTIVATE); pytest -v -n auto tests/test.py
 
 dist: clean-dist $(VENV)
 	python setup.py sdist

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,7 @@
+bumpversion
+flake8
+pytest
+pytest-xdist
+readme_renderer[md]
+tox
+twine

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
+backports.tempfile
 bumpversion
 flake8
 pytest

--- a/tests/test-environment-variable/run-tox.sh
+++ b/tests/test-environment-variable/run-tox.sh
@@ -1,4 +1,0 @@
-#!/bin/bash -x
-
-export TOX_PIP_VERSION='18.1'
-"$@"

--- a/tests/test-two-envs/tox.ini
+++ b/tests/test-two-envs/tox.ini
@@ -5,7 +5,6 @@ minversion = 2.0
 skipsdist = True
 
 [testenv]
-basepython = python3
 whitelist_externals = bash
 
 [testenv:pip18_1]

--- a/tests/test.py
+++ b/tests/test.py
@@ -18,6 +18,12 @@ TOX_VERSIONS = [
     ">=3.8,<3.9",
 ]
 
+TOX_TO_TOX_VENV_VERSIONS = {
+    # tox-venv 0.4.0 requires tox>=3.8.1
+    ">=3.7,<3.8": "<0.4.0",
+    ">=3.8,<3.9": ">=0.4.0",
+}
+
 CASES = {
     "test-two-envs": {
         "env": {},
@@ -36,18 +42,16 @@ PYTEST_PARAMETERS = sorted(itertools.product(TOX_VERSIONS, CASES))
 def setup_fresh_venv(tag, *extra_commands):
     temp_dir = tempfile.TemporaryDirectory(prefix=tag)
     venv_dir = os.path.join(temp_dir.name, 'venv')
-    p = subprocess.Popen(["virtualenv", venv_dir])
-    p.wait()
-    assert p.returncode == 0, "Failed to create venv in '%s'" % venv_dir
+    subprocess.check_call(["virtualenv", venv_dir])
+    print('Created venv: %s' % venv_dir)
     return temp_dir, venv_dir
 
 
-def install_dep(venv_dir, deps):
+def install_deps(venv_dir, *deps):
     """Install a dependency into the virtualenv"""
     pip = os.path.join(venv_dir, 'bin', 'pip')
-    p = subprocess.Popen([pip, "install", deps], cwd=venv_dir, env={})
-    p.wait()
-    assert p.returncode == 0, "Failed to install deps: '%s'" % deps
+    cmd = [pip, "install"] + list(deps)
+    subprocess.check_call(cmd, cwd=venv_dir, env={})
 
 
 def _run_case(venv_dir, subdirectory, env=None):
@@ -56,24 +60,25 @@ def _run_case(venv_dir, subdirectory, env=None):
     activate = os.path.join(venv_dir, 'bin', 'activate')
     command = '. %s; pip freeze; tox --workdir %s' % (activate, tox_work_dir)
     print("Running: '%s'" % command)
-    p = subprocess.Popen(
-        command,
-        cwd=directory,
-        shell=True,
-        env=env or {},
-    )
-    p.wait()
-    assert p.returncode == 0, "Failure in directory '%s'" % directory
+    subprocess.check_call(command, cwd=directory, shell=True, env=env or {})
 
 
 @pytest.mark.parametrize("tox_version,subdirectory", PYTEST_PARAMETERS)
 def test_with_tox_version(tox_version, subdirectory):
     env = CASES[subdirectory]['env']
-
     temp_dir, venv_dir = setup_fresh_venv(tag=subdirectory)
     try:
-        install_dep(venv_dir, "tox%s" % tox_version)
-        install_dep(venv_dir, "%s" % PACKAGE_DIR)
+        # Sometimes see an error like,
+        #
+        #    Could not find a version that satisfies the requirement
+        #    tox<3.8,>=3.7 (from versions: none)
+        #
+        # Trying separate install commands due to suspicion that the directory
+        # installation is what causes this. tox-pip-version has `tox>=2.0` and
+        # we install something like `tox<3.8,>=3.7`. Maybe that combo causes
+        # some sort of issue?
+        install_deps(venv_dir, "tox%s" % tox_version)
+        install_deps(venv_dir, PACKAGE_DIR)
         _run_case(venv_dir, subdirectory, env=env)
     finally:
         temp_dir.cleanup()
@@ -82,12 +87,14 @@ def test_with_tox_version(tox_version, subdirectory):
 @pytest.mark.parametrize("tox_version,subdirectory", PYTEST_PARAMETERS)
 def test_with_tox_version_with_tox_venv(tox_version, subdirectory):
     env = CASES[subdirectory]['env']
+    tox_venv_version = TOX_TO_TOX_VENV_VERSIONS[tox_version]
 
     temp_dir, venv_dir = setup_fresh_venv(tag=subdirectory)
     try:
-        install_dep(venv_dir, "tox%s" % tox_version)
-        install_dep(venv_dir, "%s" % PACKAGE_DIR)
-        install_dep(venv_dir, "tox-venv")
+        install_deps(
+            venv_dir, "tox%s" % tox_version, "tox-venv%s" % tox_venv_version
+        )
+        install_deps(venv_dir, PACKAGE_DIR)
         _run_case(venv_dir, subdirectory, env=env)
     finally:
         temp_dir.cleanup()

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,0 +1,94 @@
+import itertools
+import os
+import subprocess
+import tempfile
+
+import pytest
+
+HERE = os.path.realpath(os.path.dirname(__file__))
+PACKAGE_DIR = os.path.realpath(os.path.join(HERE, '..'))
+
+TOX_VERSIONS = [
+    ">=3.7,<3.8",
+    ">=3.8,<3.9",
+]
+
+CASES = {
+    "test-two-envs": {
+        "env": {},
+    },
+    "test-env-inheritance": {
+        "env": {},
+    },
+    "test-environment-variable": {
+        "env": {"TOX_PIP_VERSION": "18.1"},
+    },
+}
+
+
+def setup_fresh_venv(tag, *extra_commands):
+    temp_dir = tempfile.TemporaryDirectory(prefix=tag)
+    venv_dir = os.path.join(temp_dir.name, 'venv')
+    p = subprocess.Popen(["virtualenv", venv_dir])
+    p.wait()
+    assert p.returncode == 0, "Failed to create venv in '%s'" % venv_dir
+    return temp_dir, venv_dir
+
+
+def install_dep(venv_dir, deps):
+    """Install a dependency into the virtualenv"""
+    pip = os.path.join(venv_dir, 'bin', 'pip')
+    p = subprocess.Popen([pip, "install", deps], cwd=venv_dir, env={})
+    p.wait()
+    assert p.returncode == 0, "Failed to install deps: '%s'" % deps
+
+
+def _run_case(venv_dir, subdirectory, env=None):
+    tox_work_dir = os.path.join(venv_dir, '.tox')
+    directory = os.path.join(HERE, subdirectory)
+    activate = os.path.join(venv_dir, 'bin', 'activate')
+    command = '. %s; pip freeze; tox --workdir %s' % (activate, tox_work_dir)
+    print("Running: '%s'" % command)
+    p = subprocess.Popen(
+        command,
+        cwd=directory,
+        shell=True,
+        env=env or {},
+    )
+    p.wait()
+    assert p.returncode == 0, "Failure in directory '%s'" % directory
+
+
+@pytest.mark.parametrize(
+    "tox_version,subdirectory",
+    list(itertools.product(TOX_VERSIONS, CASES.keys()))
+)
+def test_with_tox_version(tox_version, subdirectory):
+    env = CASES[subdirectory]['env']
+
+    temp_dir, venv_dir = setup_fresh_venv(tag=subdirectory)
+    try:
+        install_dep(venv_dir, "tox%s" % tox_version)
+        install_dep(venv_dir, "%s" % PACKAGE_DIR)
+        _run_case(venv_dir, subdirectory, env=env)
+    finally:
+        temp_dir.cleanup()
+
+
+@pytest.mark.parametrize(
+    "tox_version,subdirectory",
+    list(itertools.product(TOX_VERSIONS, CASES.keys()))
+)
+def test_with_tox_version_with_tox_venv(tox_version, subdirectory):
+    env = CASES[subdirectory]['env']
+
+    temp_dir, venv_dir = setup_fresh_venv(tag=subdirectory)
+    try:
+        install_dep(venv_dir, "tox%s" % tox_version)
+        install_dep(venv_dir, "%s" % PACKAGE_DIR)
+        install_dep(venv_dir, "tox-venv")
+        _run_case(venv_dir, subdirectory, env=env)
+    finally:
+        temp_dir.cleanup()
+
+

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,7 +1,12 @@
 import itertools
 import os
 import subprocess
-import tempfile
+import sys
+
+if sys.version_info.major == 2:
+    from backports import tempfile
+else:
+    import tempfile
 
 import pytest
 
@@ -24,6 +29,8 @@ CASES = {
         "env": {"TOX_PIP_VERSION": "18.1"},
     },
 }
+
+PYTEST_PARAMETERS = sorted(itertools.product(TOX_VERSIONS, CASES))
 
 
 def setup_fresh_venv(tag, *extra_commands):
@@ -59,10 +66,7 @@ def _run_case(venv_dir, subdirectory, env=None):
     assert p.returncode == 0, "Failure in directory '%s'" % directory
 
 
-@pytest.mark.parametrize(
-    "tox_version,subdirectory",
-    list(itertools.product(TOX_VERSIONS, CASES.keys()))
-)
+@pytest.mark.parametrize("tox_version,subdirectory", PYTEST_PARAMETERS)
 def test_with_tox_version(tox_version, subdirectory):
     env = CASES[subdirectory]['env']
 
@@ -75,10 +79,7 @@ def test_with_tox_version(tox_version, subdirectory):
         temp_dir.cleanup()
 
 
-@pytest.mark.parametrize(
-    "tox_version,subdirectory",
-    list(itertools.product(TOX_VERSIONS, CASES.keys()))
-)
+@pytest.mark.parametrize("tox_version,subdirectory", PYTEST_PARAMETERS)
 def test_with_tox_version_with_tox_venv(tox_version, subdirectory):
     env = CASES[subdirectory]['env']
 
@@ -90,5 +91,3 @@ def test_with_tox_version_with_tox_venv(tox_version, subdirectory):
         _run_case(venv_dir, subdirectory, env=env)
     finally:
         temp_dir.cleanup()
-
-

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,6 @@ usedevelop = True
 minversion = 2.0
 skipsdist = True
 
-[testenv]
-basepython = python3
-whitelist_externals =
-  /bin/bash
-
 [testenv:flake8]
 deps = flake8
 commands = flake8 ./tox_pip_version

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pip18_1, pip19_0_1, flake8, pip18_1_env
+envlist = flake8
 usedevelop = True
 minversion = 2.0
 skipsdist = True
@@ -9,22 +9,6 @@ basepython = python3
 whitelist_externals =
   /bin/bash
 
-[testenv:pip18_1]
-pip_version = 18.1
-commands =
-  bash ./tests/check-pip-version.sh 18.1
-
-[testenv:pip19_0_1]
-pip_version = 19.0.1
-commands =
-  bash ./tests/check-pip-version.sh 19.0.1
-
 [testenv:flake8]
 deps = flake8
 commands = flake8 ./tox_pip_version
-
-[testenv:pip18_1_env]
-setenv =
-  TOX_PIP_VERSION=18.1
-commands =
-  bash ./tests/check-pip-version.sh 18.1


### PR DESCRIPTION
- Pass `tryfirst=True` to the hookimpl decorator. This ensures our
plugin runs before tox-venv's does, and since we return non-None,
tox-venv's plugin is not invoked afterwards.
- If tox-venv is installed, call tox-venv's `tox_testenv_create`
directly to create the virtualenv.

Those two changes ensure tox-venv creates the virtualenv only once, and
that it occurs before we install a particular pip version.

Additionally, I reworked the tests and did a little cleanup.

- There's now a `tests/test.py` file that we run with pytest
- `test.py` isolates tests so we can run them in parallel. It creates a
fresh venv in an isolated temporary directory for each test case, and
places the tox workdir in that temporary directory as well.
- Cleanup now unused pieces of the Makefile
- Put dependencies into dev-requirements.txt

Fixes #11 