### PR TITLE
Support tox-conda

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.6
+current_version = 0.0.7
 files = setup.py
 commit = True
 tag = True

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type='text/markdown',
     url='https://github.com/pglass/tox-pip-version',
     license='MIT',
-    version='0.0.6',
+    version='0.0.7',
     packages=setuptools.find_packages(),
     include_package_data=True,
     install_requires=['tox>=2.0'],


### PR DESCRIPTION
For #23, detect and run tox-conda similar to the how we handle tox-venv.

- [ ] ~TODO: Needs test cases~ Created an issue for tests https://github.com/pglass/tox-pip-version/issues/25

I manually tested this locally (see below)

----

```
$ tox
GLOB sdist-make: /Users/pglass/toxconda/setup.py
py35 create: /Users/pglass/toxconda/.tox/py35
py35: pip_version is pip==18
py35 inst: /Users/pglass/toxconda/.tox/.tmp/package/1/wumbo-0.0.1.zip
py35 installed: You are using pip version 18.0, however version 20.0.2 is available.,You should consider upgrading via the 'pip install --upgrade pip' command.,certifi==2018.8.24,wumbo==0.0.1
py35 run-test-pre: PYTHONHASHSEED='669484105'
py35 run-test: commands[0] | python -s -c 'import sys;print(sys.version)'
3.5.6 |Anaconda, Inc.| (default, Aug 26 2018, 16:30:03)
[GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)]
py36 create: /Users/pglass/toxconda/.tox/py36
py36: pip_version is pip==18
py36 inst: /Users/pglass/toxconda/.tox/.tmp/package/1/wumbo-0.0.1.zip
py36 installed: You are using pip version 18.0, however version 20.0.2 is available.,You should consider upgrading via the 'pip install --upgrade pip' command.,certifi==2019.11.28,wumbo==0.0.1
py36 run-test-pre: PYTHONHASHSEED='669484105'
py36 run-test: commands[0] | python -s -c 'import sys;print(sys.version)'
3.6.10 |Anaconda, Inc.| (default, Jan  7 2020, 15:01:53)
[GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)]
______________________________________________________ summary _______________________________________________________
  py35: commands succeeded
  py36: commands succeeded
  congratulations :)
```