### PR TITLE
Limit readme-renderer to <25.0 on py34 and older

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,7 +4,7 @@ flake8
 packaging
 pytest
 pytest-xdist
-readme_renderer[md]
+readme_renderer[md];python_version>="3.5"
 readme_renderer[md]<25.0;python_version<"3.5"
 tox
 twine

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,6 +5,6 @@ packaging
 pytest
 pytest-xdist
 readme_renderer[md]
-readme_renderer[md]<25.0;python_version<3.5
+readme_renderer[md]<25.0;python_version<"3.5"
 tox
 twine

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,5 +5,6 @@ packaging
 pytest
 pytest-xdist
 readme_renderer[md]
+readme_renderer[md]<25.0;python_version<3.5
 tox
 twine


### PR DESCRIPTION
Fixes #28.